### PR TITLE
Fix the logic to read SMARTPAY_API_PREFIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,14 +98,20 @@ Then, you can redirect your customer to the session url by calling `redirectUrl`
 $session->redirectUrl()
 ```
 
-## Contributing
+## Test
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/smartpay. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/smartpay/blob/master/CODE_OF_CONDUCT.md).
+Install dependencies
+
+```shell
+composer i
+```
+
+Run test in the folder
+
+```shell
+./vendor/bin/phpunit tests
+```
 
 ## License
 
 The package is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
-
-## Code of Conduct
-
-Everyone interacting in the Smartpay project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/smartpay/blob/master/CODE_OF_CONDUCT.md).

--- a/src/Requests/CheckoutSession.php
+++ b/src/Requests/CheckoutSession.php
@@ -80,15 +80,30 @@ class CheckoutSession
 		if (array_key_exists('orderData', $this->rawPayload)) {
 			if (array_key_exists('amount', $this->rawPayload['orderData'])) {
 				$this->amount = $this->rawPayload['orderData']['amount'];
+
+				return;
 			}
 		}
 
-		if ($this->amount === 0.0) {
-			if (count($this->item) > 0) {
-				for ($i = 0; $i < count($this->item); ++$i) {
-					if (array_key_exists('amount', $this->item[$i])) {
-						$this->amount += $this->item[$i]['amount'];
-					}
+		if (
+			array_key_exists('shipping', $this->rawPayload) &&
+			array_key_exists('feeAmount', $this->rawPayload['shipping'])
+		) {
+			$this->amount = $this->rawPayload['shipping']['feeAmount'];
+		}
+
+		if (
+			array_key_exists('orderData', $this->rawPayload) &&
+			array_key_exists('shippingInfo', $this->rawPayload['orderData']) &&
+			array_key_exists('feeAmount', $this->rawPayload['orderData']['shippingInfo'])
+		) {
+			$this->amount = $this->rawPayload['orderData']['shippingInfo']['amount'];
+		}
+
+		if (count($this->item) > 0) {
+			for ($i = 0; $i < count($this->item); ++$i) {
+				if (array_key_exists('amount', $this->item[$i])) {
+					$this->amount += $this->item[$i]['amount'];
 				}
 			}
 		}

--- a/src/Smartpay.php
+++ b/src/Smartpay.php
@@ -23,9 +23,7 @@ class Smartpay
 
     public static function reset()
     {
-        $SMARTPAY_API_PREFIX = getenv('SMARTPAY_API_PREFIX');
-
-        self::$apiUrl = $SMARTPAY_API_PREFIX ? $SMARTPAY_API_PREFIX : self::DEFAULT_API_URL;
+        self::$apiUrl = self::DEFAULT_API_URL;
         self::$checkoutUrl = self::DEFAULT_CHECKOUT_URL;
         self::$postTimeout = self::DEFAULT_POST_TIMEOUT;
         self::$publicKey = null;
@@ -90,4 +88,15 @@ class Smartpay
     {
         return self::$secretKey;
     }
+}
+
+$SMARTPAY_API_PREFIX = getenv('SMARTPAY_API_PREFIX');
+$SMARTPAY_CHECKOUT_URL = getenv('SMARTPAY_CHECKOUT_URL');
+
+if ($SMARTPAY_API_PREFIX) {
+    Smartpay::setApiUrl($SMARTPAY_API_PREFIX);
+}
+
+if ($SMARTPAY_CHECKOUT_URL) {
+    Smartpay::setCheckoutUrl($SMARTPAY_CHECKOUT_URL);
 }

--- a/tests/Requests/CheckoutSessionTest.php
+++ b/tests/Requests/CheckoutSessionTest.php
@@ -39,7 +39,8 @@ final class CheckoutSessionTest extends TestCase
                 "line1" => "line1",
                 "locality" => "locality",
                 "postalCode" => "123",
-                "country" => "JP"
+                "country" => "JP",
+                "feeAmount" => 100,
             ],
             "reference" => "order_ref_1234567",
             "successURL" => "https://docs.smartpay.co/example-pages/checkout-successful",
@@ -71,7 +72,7 @@ final class CheckoutSessionTest extends TestCase
                 "reference" => null
             ],
             "orderData" => [
-                "amount" => 250.0,
+                "amount" => 350.0,
                 "captureMethod" => null,
                 "confirmationMethod" => null,
                 "coupons" => null,
@@ -112,7 +113,7 @@ final class CheckoutSessionTest extends TestCase
                         "subLocality" => null
                     ],
                     "addressType" => null,
-                    "feeAmount" => null,
+                    "feeAmount" => 100,
                     "feeCurrency" => "JPY"
                 ]
             ],


### PR DESCRIPTION
Several updates:

- Fix the code to read ENV_VAR SMARTPAY_API_PREFIX
- Supports new ENV_VAR SMARTPAY_CHECKOUT_URL
- The amount should include the shipping fee
- Fix test
- Update doc to add how to run test