### PR TITLE
reorganize the request payload: move the keys of reference and metadata to the hash of orderData

### DIFF
--- a/src/Requests/CheckoutSession.php
+++ b/src/Requests/CheckoutSession.php
@@ -112,22 +112,9 @@ class CheckoutSession
 
 	private function normalize()
 	{
-		$promotionCode = $this->getOrNull($this->rawPayload, 'promotionCode');
-		$metadata = $this->getOrNull($this->rawPayload, 'metadata');
-
-		if ($promotionCode) {
-			if (!$metadata) {
-				$metadata = [];
-			}
-
-			$metadata['__promotion_code__'] = $promotionCode;
-		}
-
 		return [
 			'customerInfo' => $this->normalizeCustomerInfo(),
 			'orderData' => $this->normalizeOrderData(),
-			'reference' => $this->getOrNull($this->rawPayload, 'reference'),
-			'metadata' => $metadata,
 			'successUrl' => $this->getOrNull($this->rawPayload, 'successURL'),
 			'cancelUrl' => $this->getOrNull($this->rawPayload, 'cancelURL'),
 		];
@@ -172,6 +159,9 @@ class CheckoutSession
 			? $this->normalizeItemData($this->getOrNull($this->rawPayload, 'items'))
 			: $this->normalizeItemData($this->rawPayload['lineItemData']);
 
+		$metadata = is_null($this->getOrNull($this->rawPayload, 'metadata'))
+			? [] : $this->rawPayload['metadata'];
+
 		return [
 			'amount' => $this->amount,
 			'currency' => $this->currency,
@@ -180,6 +170,8 @@ class CheckoutSession
 			'coupons' => $this->getOrNull($this->rawPayload, 'coupons'),
 			'shippingInfo' => $shiippingInfo,
 			'lineItemData' => $items,
+			'reference' => $this->getOrNull($this->rawPayload, 'reference'),
+			'metadata' => $metadata
 		];
 	}
 

--- a/tests/Requests/CheckoutSessionTest.php
+++ b/tests/Requests/CheckoutSessionTest.php
@@ -7,128 +7,7 @@ use Smartpay\Requests\CheckoutSession;
 
 final class CheckoutSessionTest extends TestCase
 {
-    public function testToRequest_1()
-    {
-        $CODE = "ZOO";
-
-        $payload = [
-            "items" => [[
-                "name" => "オリジナルス STAN SMITH",
-                "amount" => 250,
-                "currency" => "JPY",
-                "quantity" => 1
-            ]],
-            "customer" => [
-                "accountAge" => 20,
-                "email" => "merchant-support@smartpay.co",
-                "firstName" => "田中",
-                "lastName" => "太郎",
-                "firstNameKana" => "たなか",
-                "lastNameKana" => "たろう",
-                "address" => [
-                    "line1" => "3-6-7",
-                    "line2" => "青山パラシオタワー 11階",
-                    "subLocality" => "",
-                    "locality" => "港区北青山",
-                    "administrativeArea" => "東京都",
-                    "postalCode" => "107-0061",
-                    "country" => "JP"
-                ],
-                "dateOfBirth" => "1985-06-30",
-                "gender" => "male"
-            ],
-            "shipping" => [
-                "line1" => "line1",
-                "locality" => "locality",
-                "postalCode" => "123",
-                "country" => "JP",
-                "feeAmount" => 100,
-            ],
-            "reference" => "order_ref_1234567",
-            "successURL" => "https://docs.smartpay.co/example-pages/checkout-successful",
-            "cancelURL" => "https://docs.smartpay.co/example-pages/checkout-canceled",
-            "promotionCode" => $CODE,
-        ];
-
-        $request = new CheckoutSession($payload);
-        $this->assertEquals($request->toRequest(), [
-            "customerInfo" => [
-                "accountAge" => 20,
-                "address" => [
-                    "administrativeArea" => "東京都",
-                    "country" => "JP",
-                    "line1" => "3-6-7",
-                    "line2" => "青山パラシオタワー 11階",
-                    "locality" => "港区北青山",
-                    "postalCode" => "107-0061",
-                    "subLocality" => ""
-                ],
-                "dateOfBirth" => "1985-06-30",
-                "emailAddress" => "merchant-support@smartpay.co",
-                "firstName" => "田中",
-                "firstNameKana" => "たなか",
-                "lastName" => "太郎",
-                "lastNameKana" => "たろう",
-                "legalGender" => "male",
-                "phoneNumber" => null,
-                "reference" => null
-            ],
-            "orderData" => [
-                "amount" => 350.0,
-                "captureMethod" => null,
-                "confirmationMethod" => null,
-                "coupons" => null,
-                "currency" => "JPY",
-                "lineItemData" => [[
-                    "description" => null,
-                    "metadata" => null,
-                    "price" => null,
-                    "priceData" => [
-                        "amount" => 250.0,
-                        "currency" => "JPY",
-                        "metadata" => null,
-                        "productData" => [
-                            "brand" => null,
-                            "categories" => null,
-                            "description" => null,
-                            "gtin" => null,
-                            "images" => null,
-                            "metadata" => null,
-                            "name" => "オリジナルス STAN SMITH",
-                            "reference" => null,
-                            "url" => null
-                        ]
-                    ],
-                    "quantity" => 1
-                ]],
-                "shippingInfo" => [
-                    "address" => [
-                        "administrativeArea" => null,
-                        "country" => "JP",
-                        "line1" => "line1",
-                        "line2" => null,
-                        "line3" => null,
-                        "line4" => null,
-                        "line5" => null,
-                        "locality" => "locality",
-                        "postalCode" => "123",
-                        "subLocality" => null
-                    ],
-                    "addressType" => null,
-                    "feeAmount" => 100,
-                    "feeCurrency" => "JPY"
-                ]
-            ],
-            "reference" => "order_ref_1234567",
-            "metadata" => [
-                "__promotion_code__" => $CODE,
-            ],
-            "successUrl" => "https://docs.smartpay.co/example-pages/checkout-successful",
-            "cancelUrl" => "https://docs.smartpay.co/example-pages/checkout-canceled",
-        ]);
-    }
-
-    public function testToRequest_2()
+    public function testToRequest()
     {
         $payload = [
             "items" => [[
@@ -191,6 +70,8 @@ final class CheckoutSessionTest extends TestCase
                 "reference" => null
             ],
             "orderData" => [
+                "reference" => "order_ref_1234567",
+                "metadata" => [],
                 "amount" => 250.0,
                 "captureMethod" => null,
                 "confirmationMethod" => null,
@@ -235,8 +116,6 @@ final class CheckoutSessionTest extends TestCase
                     "feeCurrency" => "JPY"
                 ]
             ],
-            "reference" => "order_ref_1234567",
-            "metadata" => [],
             "successUrl" => "https://docs.smartpay.co/example-pages/checkout-successful",
             "cancelUrl" => "https://docs.smartpay.co/example-pages/checkout-canceled",
         ]);


### PR DESCRIPTION
The implementation in this PR mainly references the commit in python SDK:

https://github.com/smartpay-co/sdk-python/commit/4f358925c42dd804b8b1a93e665d0d62c8357501

- reorganize the request payload: move the keys of reference and metadata to the hash of orderData
- remove promotion code from metadata (-> not sure if this change are necessary)