### PR TITLE
feat: add phpunit-polyfills to support PHP 8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ integration-test: guard-SMARTPAY_SECRET_KEY guard-SMARTPAY_PUBLIC_KEY guard-API_
 test: guard-SMARTPAY_SECRET_KEY guard-SMARTPAY_PUBLIC_KEY guard-API_BASE
 	XDEBUG_MODE=coverage vendor/bin/phpunit tests --testdox --coverage-text --whitelist src/
 
+clean-composer:
+	rm -rf composer.lock vendor
 
 guard-%: GUARD
 	@ if [ -z '${${*}}' ]; then echo 'Environment variable $* not set.' && exit 1; fi

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,10 @@
     "caseyamcl/guzzle_retry_middleware": "^2.2"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.7",
+    "phpunit/phpunit": ">= 5.7",
     "squizlabs/php_codesniffer": "^3.3",
-    "friendsofphp/php-cs-fixer": "2.17.1"
+    "friendsofphp/php-cs-fixer": ">= 2.19.3",
+    "yoast/phpunit-polyfills": "^1.0"
   },
   "autoload": {
     "psr-4": {

--- a/tests/Integrations/OrderLifeCycleTest.php
+++ b/tests/Integrations/OrderLifeCycleTest.php
@@ -8,7 +8,7 @@ use Smartpay\Smartpay;
 
 use GuzzleHttp\Client as GuzzleClient;
 
-final class OrderLifecycleTest extends TestCase
+final class OrderLifeCycleTest extends TestCase
 {
     public function testOrderLifecycle()
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,9 +4,9 @@ namespace Tests;
 
 use Smartpay\Smartpay;
 
-abstract class TestCase extends \PHPUnit\Framework\TestCase
+abstract class TestCase extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 {
-    public function setUp()
+    public function set_up()
     {
         Smartpay::reset();
 
@@ -22,7 +22,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         }
     }
 
-    public function tearDown()
+    public function tear_down()
     {
         Smartpay::reset();
     }


### PR DESCRIPTION
- Use [PHPUnit-Polyfills](https://github.com/Yoast/PHPUnit-Polyfills) to support PHP 5.6 ~ PHP 8.1

Tested with PHP 5.6, PHP7.4, PHP 8.1

Signed-off-by: Ash Wu <hsatac@gmail.com>